### PR TITLE
Feature/for loop export macros

### DIFF
--- a/docs/tags.md
+++ b/docs/tags.md
@@ -10,6 +10,7 @@ Implemented tags so far which needs documentation:
 * comment
 * cycle
 * extends
+* exec
 * filter
 * firstof
 * for

--- a/tags_exec.go
+++ b/tags_exec.go
@@ -1,0 +1,70 @@
+package pongo2
+
+import (
+	"bytes"
+)
+
+type tagExecNode struct {
+	position    *Token
+	bodyWrapper *NodeWrapper
+}
+
+func (node *tagExecNode) Execute(ctx *ExecutionContext, writer TemplateWriter) *Error {
+	temp := bytes.NewBuffer(make([]byte, 0, 1024)) // 1 KiB size
+
+	err := node.bodyWrapper.Execute(ctx, temp)
+	if err != nil {
+		return err
+	}
+	templateSet := ctx.template.set
+	newContext := make(Context)
+	newContext.Update(ctx.Private)
+	newContext.Update(ctx.Public)
+	s := temp.String()
+	currentTemplate, _ := templateSet.FromString(s)
+	finalRes, _ := currentTemplate.Execute(newContext)
+	moveMacrosToMainTemplate(currentTemplate, ctx)
+
+	_, err2 := writer.WriteString(finalRes)
+	if err2 != nil {
+		return nil
+	}
+
+	return nil
+}
+
+func moveMacrosToMainTemplate(template *Template, context *ExecutionContext) {
+	for _, macro := range template.exportedMacros {
+		macro.Execute(context, nil)
+	}
+	for _, node := range template.root.Nodes {
+		importNode, ok := node.(*tagImportNode)
+		if ok {
+			for _, macro := range importNode.macros {
+				macro.Execute(context, nil)
+			}
+		}
+		macroNode, ok := node.(*tagMacroNode)
+		if ok {
+			macroNode.Execute(context, nil)
+		}
+	}
+}
+
+func tagExecuteParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Error) {
+	execNode := &tagExecNode{
+		position: start,
+	}
+
+	wrapper, _, err := doc.WrapUntilTag("endexec")
+	if err != nil {
+		return nil, err
+	}
+	execNode.bodyWrapper = wrapper
+
+	return execNode, nil
+}
+
+func init() {
+	RegisterTag("exec", tagExecuteParser)
+}

--- a/tags_exec.go
+++ b/tags_exec.go
@@ -2,6 +2,7 @@ package pongo2
 
 import (
 	"bytes"
+	"log"
 )
 
 type tagExecNode struct {
@@ -17,11 +18,18 @@ func (node *tagExecNode) Execute(ctx *ExecutionContext, writer TemplateWriter) *
 		return err
 	}
 	templateSet := ctx.template.set
+	s := temp.String()
+	currentTemplate, _ := templateSet.FromString(s)
+	if currentTemplate == nil {
+		log.Fatalf("Could not read template %s, please check the syntax", s)
+	}
+
+	// New context with global, public and private context
+	// we need all 3
 	newContext := make(Context)
 	newContext.Update(ctx.Private)
 	newContext.Update(ctx.Public)
-	s := temp.String()
-	currentTemplate, _ := templateSet.FromString(s)
+	newContext.Update(templateSet.Globals)
 	finalRes, _ := currentTemplate.Execute(newContext)
 	moveMacrosToMainTemplate(currentTemplate, ctx)
 
@@ -29,7 +37,6 @@ func (node *tagExecNode) Execute(ctx *ExecutionContext, writer TemplateWriter) *
 	if err2 != nil {
 		return nil
 	}
-
 	return nil
 }
 

--- a/tags_exec.go
+++ b/tags_exec.go
@@ -25,11 +25,11 @@ func (node *tagExecNode) Execute(ctx *ExecutionContext, writer TemplateWriter) *
 	}
 
 	// New context with global, public and private context
-	// we need all 3
+	// we need all 3, globals comes from templateSet,
+	// public for all variables passed, private for macros etc defined in amin template
 	newContext := make(Context)
 	newContext.Update(ctx.Private)
 	newContext.Update(ctx.Public)
-	newContext.Update(templateSet.Globals)
 	finalRes, _ := currentTemplate.Execute(newContext)
 	moveMacrosToMainTemplate(currentTemplate, ctx)
 

--- a/template_tests/exec.helper
+++ b/template_tests/exec.helper
@@ -1,0 +1,1 @@
+{% macro m4(arg) export %}{{arg}}{% endmacro %}

--- a/template_tests/exec.tpl
+++ b/template_tests/exec.tpl
@@ -1,0 +1,13 @@
+{% with val = "{{ simple.name }}" %}{% exec %}{{val}}{% endexec %}{% endwith %}
+
+{% exec %}{% macro m1() %}some text{% endmacro %}{% endexec %}{{m1()}}
+
+{% exec %}{% autoescape off %}{% macro m2(arg) export %}some text with {{arg}}{% endmacro %}{% endautoescape %}{% endexec %}{{m2("arg value")}}
+
+{% with val = "{% macro m3() export %}m3 text{% endmacro %}{{m3()}}" %}{% exec %}{{val}}{% endexec %}{% endwith %}
+
+{% with val = '{% import "template_tests/exec.helper" m4 %}' %}{% exec %}{% autoescape off %}{{val}}{% endautoescape %}{% endexec %}{{m4("arg value")}}{% endwith %}
+
+{% exec %}{% macro m1() export %}some text{% endmacro %}{% endexec %}{{m1()}}
+
+{% with chars = "abc"|make_list val = "{% for i in chars %}{{i}}{% endfor %}" %}{% exec %}{{val}}{% endexec %}{% endwith %}

--- a/template_tests/exec.tpl.out
+++ b/template_tests/exec.tpl.out
@@ -1,0 +1,13 @@
+john doe
+
+some text
+
+some text with arg value
+
+m3 text
+
+arg value
+
+some text
+
+abc


### PR DESCRIPTION
## Description of the change

Adding functionality to be able to define and import macro within a for loop to be used in the rest of the template. Key is using `exportmacros` as an identifier in for loop. In the below template abc = [1,2]

```
{% for x in abc exportmacros %}
    {% if x == 1 %}
        {% import "x.template" m4 %}
    {% else %}
        {% macro m5() export %}
            m5 value
        {% endmacro %}
    {% endif %}
{% endfor %}
--
{{m5()}}
{{m4()}}
```

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
