### PR TITLE
added exportmacro identifier in for loop

### DIFF
--- a/template_tests/for.tpl
+++ b/template_tests/for.tpl
@@ -25,3 +25,6 @@ reversed sorted string map
 
 reversed sorted int map
 '{% for key in simple.intmap reversed sorted %}{{ key }} {% endfor %}'
+
+exportmacros
+{% for x in simple.fixed_item_list exportmacros %}{% if x == 1 %}{% import "macro.helper" imported_macro %}{% else %}{% macro defined_macro(arg) export %}Bye {{arg}}{% endmacro %}{% endif %}{% endfor %}{{imported_macro("a")}} {{defined_macro("a")}}

--- a/template_tests/for.tpl.out
+++ b/template_tests/for.tpl.out
@@ -35,3 +35,6 @@ reversed sorted string map
 
 reversed sorted int map
 '5 2 1 '
+
+exportmacros
+<p>Hey a!</p> Bye a


### PR DESCRIPTION
## Description of the change

Adding functionality to be able to define and import macro within a for loop to be used in the rest of the template. Key is using `exportmacros` as an identifier in for loop. In the below template abc = [1,2]

```
{% for x in abc exportmacros %}
    {% if x == 1 %}
        {% import "x.template" m4 %}
    {% else %}
        {% macro m5() export %}
            m5 value
        {% endmacro %}
    {% endif %}
{% endfor %}
--
{{m5()}}
{{m4()}}
```

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
