### PR TITLE
Private Variable exportedMacros can be accessed. 

### DIFF
--- a/template.go
+++ b/template.go
@@ -56,6 +56,10 @@ func newTemplateString(set *TemplateSet, tpl []byte) (*Template, error) {
 	return newTemplate(set, "<string>", true, tpl)
 }
 
+func (tpl *Template) GetExportedMacros() map[string]*tagMacroNode {
+	return tpl.exportedMacros
+}
+
 func newTemplate(set *TemplateSet, name string, isTplString bool, tpl []byte) (*Template, error) {
 	strTpl := string(tpl)
 


### PR DESCRIPTION
## Description of the change
Exported Macros are accessible now with the function GetExportedMacros.
> Description here

## Type of change
-  New feature (non-breaking change that adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
