### PR TITLE
fix: wrapping errors for detecting custom errors

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,7 +1,6 @@
 package pongo2
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 )
@@ -108,8 +107,8 @@ func NewChildExecutionContext(parent *ExecutionContext) *ExecutionContext {
 	return newctx
 }
 
-func (ctx *ExecutionContext) Error(msg string, token *Token) *Error {
-	return ctx.OrigError(errors.New(msg), token)
+func (ctx *ExecutionContext) Error(err error, token *Token) *Error {
+	return ctx.OrigError(err, token)
 }
 
 func (ctx *ExecutionContext) OrigError(err error, token *Token) *Error {

--- a/filters.go
+++ b/filters.go
@@ -104,7 +104,7 @@ func (p *Parser) parseFilter() (*filterCall, *Error) {
 
 	// Check filter ident
 	if identToken == nil {
-		return nil, p.Error("Filter name must be an identifier.", nil)
+		return nil, p.Error(fmt.Errorf("Filter name must be an identifier."), nil)
 	}
 
 	filter := &filterCall{
@@ -115,7 +115,7 @@ func (p *Parser) parseFilter() (*filterCall, *Error) {
 	// Get the appropriate filter function and bind it
 	filterFn, exists := filters[identToken.Val]
 	if !exists {
-		return nil, p.Error(fmt.Sprintf("Filter '%s' does not exist.", identToken.Val), identToken)
+		return nil, p.Error(fmt.Errorf("Filter '%s' does not exist.", identToken.Val), identToken)
 	}
 
 	filter.filterFunc = filterFn
@@ -123,7 +123,7 @@ func (p *Parser) parseFilter() (*filterCall, *Error) {
 	// Check for filter-argument (2 tokens needed: ':' ARG)
 	if p.Match(TokenSymbol, ":") != nil {
 		if p.Peek(TokenSymbol, "}}") != nil {
-			return nil, p.Error("Filter parameter required after ':'.", nil)
+			return nil, p.Error(fmt.Errorf("Filter parameter required after ':'."), nil)
 		}
 
 		// Get filter argument expression

--- a/parser.go
+++ b/parser.go
@@ -1,7 +1,6 @@
 package pongo2
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 )
@@ -179,7 +178,7 @@ func (p *Parser) GetR(shift int) *Token {
 // The 'token'-argument is optional. If provided, it will take
 // the token's position information. If not provided, it will
 // automatically use the CURRENT token's position information.
-func (p *Parser) Error(msg string, token *Token) *Error {
+func (p *Parser) Error(err error, token *Token) *Error {
 	if token == nil {
 		// Set current token
 		token = p.Current()
@@ -202,7 +201,7 @@ func (p *Parser) Error(msg string, token *Token) *Error {
 		Line:      line,
 		Column:    col,
 		Token:     token,
-		OrigError: errors.New(msg),
+		OrigError: err,
 	}
 }
 
@@ -244,7 +243,7 @@ func (p *Parser) WrapUntilTag(names ...string) (*NodeWrapper, *Parser, *Error) {
 						t := p.Current()
 						p.Consume()
 						if t == nil {
-							return nil, nil, p.Error("Unexpected EOF.", p.lastToken)
+							return nil, nil, p.Error(fmt.Errorf("Unexpected EOF."), p.lastToken)
 						}
 						tagArgs = append(tagArgs, t)
 					}
@@ -261,7 +260,7 @@ func (p *Parser) WrapUntilTag(names ...string) (*NodeWrapper, *Parser, *Error) {
 		wrapper.nodes = append(wrapper.nodes, node)
 	}
 
-	return nil, nil, p.Error(fmt.Sprintf("Unexpected EOF, expected tag %s.", strings.Join(names, " or ")),
+	return nil, nil, p.Error(fmt.Errorf("Unexpected EOF, expected tag %s.", strings.Join(names, " or ")),
 		p.lastToken)
 }
 
@@ -298,7 +297,7 @@ func (p *Parser) SkipUntilTag(names ...string) *Error {
 						p.Consume()
 						if p.Current() == nil {
 							// EOF encountered
-							return p.Error("Unexpected EOF, expected '%}'", p.lastToken)
+							return p.Error(fmt.Errorf("Unexpected EOF, expected '%%}'"), p.lastToken)
 						}
 					}
 				}
@@ -307,9 +306,9 @@ func (p *Parser) SkipUntilTag(names ...string) *Error {
 		t := p.Current()
 		p.Consume()
 		if t == nil {
-			return p.Error("Unexpected EOF.", p.lastToken)
+			return p.Error(fmt.Errorf("Unexpected EOF."), p.lastToken)
 		}
 	}
 
-	return p.Error(fmt.Sprintf("Unexpected EOF, expected tag %s.", strings.Join(names, " or ")), p.lastToken)
+	return p.Error(fmt.Errorf("Unexpected EOF, expected tag %s.", strings.Join(names, " or ")), p.lastToken)
 }

--- a/parser_document.go
+++ b/parser_document.go
@@ -1,5 +1,7 @@
 package pongo2
 
+import "fmt"
+
 // Doc = { ( Filter | Tag | HTML ) }
 func (p *Parser) parseDocElement() (INode, *Error) {
 	t := p.Current()
@@ -31,7 +33,7 @@ func (p *Parser) parseDocElement() (INode, *Error) {
 			return tag, nil
 		}
 	}
-	return nil, p.Error("Unexpected token (only HTML/tags/filters in templates allowed)", t)
+	return nil, p.Error(fmt.Errorf("Unexpected token (only HTML/tags/filters in templates allowed)"), t)
 }
 
 func (tpl *Template) parse() *Error {

--- a/parser_expression.go
+++ b/parser_expression.go
@@ -158,7 +158,7 @@ func (expr *Expression) Evaluate(ctx *ExecutionContext) (*Value, *Error) {
 				return AsValue(v2.IsTrue()), nil
 			}
 		default:
-			return nil, ctx.Error(fmt.Sprintf("unimplemented: %s", expr.opToken.Val), expr.opToken)
+			return nil, ctx.Error(fmt.Errorf("unimplemented: %s", expr.opToken.Val), expr.opToken)
 		}
 	} else {
 		return v1, nil
@@ -217,7 +217,7 @@ func (expr *relationalExpression) Evaluate(ctx *ExecutionContext) (*Value, *Erro
 		case "in":
 			return AsValue(v2.Contains(v1)), nil
 		default:
-			return nil, ctx.Error(fmt.Sprintf("unimplemented: %s", expr.opToken.Val), expr.opToken)
+			return nil, ctx.Error(fmt.Errorf("unimplemented: %s", expr.opToken.Val), expr.opToken)
 		}
 	} else {
 		return v1, nil
@@ -243,10 +243,10 @@ func (expr *simpleExpression) Evaluate(ctx *ExecutionContext) (*Value, *Error) {
 			case result.IsInteger():
 				result = AsValue(-1 * result.Integer())
 			default:
-				return nil, ctx.Error("Operation between a number and a non-(float/integer) is not possible", nil)
+				return nil, ctx.Error(fmt.Errorf("Operation between a number and a non-(float/integer) is not possible"), nil)
 			}
 		} else {
-			return nil, ctx.Error("Negative sign on a non-number expression", expr.GetPositionToken())
+			return nil, ctx.Error(fmt.Errorf("Negative sign on a non-number expression"), expr.GetPositionToken())
 		}
 	}
 
@@ -275,7 +275,7 @@ func (expr *simpleExpression) Evaluate(ctx *ExecutionContext) (*Value, *Error) {
 			// Result will be an integer
 			return AsValue(result.Integer() - t2.Integer()), nil
 		default:
-			return nil, ctx.Error("Unimplemented", expr.GetPositionToken())
+			return nil, ctx.Error(fmt.Errorf("Unimplemented"), expr.GetPositionToken())
 		}
 	}
 
@@ -305,25 +305,25 @@ func (expr *term) Evaluate(ctx *ExecutionContext) (*Value, *Error) {
 				// Result will be float
 				divisor := f2.Float()
 				if divisor == 0 {
-					return nil, ctx.Error("float divide by zero", expr.factor2.GetPositionToken())
+					return nil, ctx.Error(fmt.Errorf("float divide by zero"), expr.factor2.GetPositionToken())
 				}
 				return AsValue(f1.Float() / divisor), nil
 			}
 			// Result will be int
 			divisor := f2.Integer()
 			if divisor == 0 {
-				return nil, ctx.Error("integer divide by zero", expr.factor2.GetPositionToken())
+				return nil, ctx.Error(fmt.Errorf("integer divide by zero"), expr.factor2.GetPositionToken())
 			}
 			return AsValue(f1.Integer() / divisor), nil
 		case "%":
 			// Result will be int
 			divisor := f2.Integer()
 			if divisor == 0 {
-				return nil, ctx.Error("integer divide by zero", expr.factor2.GetPositionToken())
+				return nil, ctx.Error(fmt.Errorf("integer divide by zero"), expr.factor2.GetPositionToken())
 			}
 			return AsValue(f1.Integer() % divisor), nil
 		default:
-			return nil, ctx.Error("unimplemented", expr.opToken)
+			return nil, ctx.Error(fmt.Errorf("unimplemented"), expr.opToken)
 		}
 	} else {
 		return f1, nil
@@ -352,7 +352,7 @@ func (p *Parser) parseFactor() (IEvaluator, *Error) {
 			return nil, err
 		}
 		if p.Match(TokenSymbol, ")") == nil {
-			return nil, p.Error("Closing bracket expected after expression", nil)
+			return nil, p.Error(fmt.Errorf("Closing bracket expected after expression"), nil)
 		}
 		return expr, nil
 	}

--- a/tags.go
+++ b/tags.go
@@ -89,19 +89,19 @@ func (p *Parser) parseTagElement() (INodeTag, *Error) {
 
 	// Check for identifier
 	if tokenName == nil {
-		return nil, p.Error("Tag name must be an identifier.", nil)
+		return nil, p.Error(fmt.Errorf("Tag name must be an identifier."), nil)
 	}
 
 	// Check for the existing tag
 	tag, exists := tags[tokenName.Val]
 	if !exists {
 		// Does not exists
-		return nil, p.Error(fmt.Sprintf("Tag '%s' not found (or beginning tag not provided)", tokenName.Val), tokenName)
+		return nil, p.Error(fmt.Errorf("Tag '%s' not found (or beginning tag not provided)", tokenName.Val), tokenName)
 	}
 
 	// Check sandbox tag restriction
 	if _, isBanned := p.template.set.bannedTags[tokenName.Val]; isBanned {
-		return nil, p.Error(fmt.Sprintf("Usage of tag '%s' is not allowed (sandbox restriction active).", tokenName.Val), tokenName)
+		return nil, p.Error(fmt.Errorf("Usage of tag '%s' is not allowed (sandbox restriction active).", tokenName.Val), tokenName)
 	}
 
 	var argsToken []*Token
@@ -113,7 +113,7 @@ func (p *Parser) parseTagElement() (INodeTag, *Error) {
 
 	// EOF?
 	if p.Remaining() == 0 {
-		return nil, p.Error("Unexpectedly reached EOF, no tag end found.", p.lastToken)
+		return nil, p.Error(fmt.Errorf("Unexpectedly reached EOF, no tag end found."), p.lastToken)
 	}
 
 	p.Match(TokenSymbol, "%}")

--- a/tags_autoescape.go
+++ b/tags_autoescape.go
@@ -1,5 +1,7 @@
 package pongo2
 
+import "fmt"
+
 type tagAutoescapeNode struct {
 	wrapper    *NodeWrapper
 	autoescape bool
@@ -30,18 +32,18 @@ func tagAutoescapeParser(doc *Parser, start *Token, arguments *Parser) (INodeTag
 
 	modeToken := arguments.MatchType(TokenIdentifier)
 	if modeToken == nil {
-		return nil, arguments.Error("A mode is required for autoescape-tag.", nil)
+		return nil, arguments.Error(fmt.Errorf("A mode is required for autoescape-tag."), nil)
 	}
 	if modeToken.Val == "on" {
 		autoescapeNode.autoescape = true
 	} else if modeToken.Val == "off" {
 		autoescapeNode.autoescape = false
 	} else {
-		return nil, arguments.Error("Only 'on' or 'off' is valid as an autoescape-mode.", nil)
+		return nil, arguments.Error(fmt.Errorf("Only 'on' or 'off' is valid as an autoescape-mode."), nil)
 	}
 
 	if arguments.Remaining() > 0 {
-		return nil, arguments.Error("Malformed autoescape-tag arguments.", nil)
+		return nil, arguments.Error(fmt.Errorf("Malformed autoescape-tag arguments."), nil)
 	}
 
 	return autoescapeNode, nil

--- a/tags_block.go
+++ b/tags_block.go
@@ -35,7 +35,7 @@ func (node *tagBlockNode) Execute(ctx *ExecutionContext, writer TemplateWriter) 
 	lenBlockWrappers := len(blockWrappers)
 
 	if lenBlockWrappers == 0 {
-		return ctx.Error("internal error: len(block_wrappers) == 0 in tagBlockNode.Execute()", nil)
+		return ctx.Error(fmt.Errorf("internal error: len(block_wrappers) == 0 in tagBlockNode.Execute()"), nil)
 	}
 
 	blockWrapper := blockWrappers[lenBlockWrappers-1]
@@ -80,16 +80,16 @@ func (t tagBlockInformation) Super() (*Value, error) {
 
 func tagBlockParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Error) {
 	if arguments.Count() == 0 {
-		return nil, arguments.Error("Tag 'block' requires an identifier.", nil)
+		return nil, arguments.Error(fmt.Errorf("Tag 'block' requires an identifier."), nil)
 	}
 
 	nameToken := arguments.MatchType(TokenIdentifier)
 	if nameToken == nil {
-		return nil, arguments.Error("First argument for tag 'block' must be an identifier.", nil)
+		return nil, arguments.Error(fmt.Errorf("First argument for tag 'block' must be an identifier."), nil)
 	}
 
 	if arguments.Remaining() != 0 {
-		return nil, arguments.Error("Tag 'block' takes exactly 1 argument (an identifier).", nil)
+		return nil, arguments.Error(fmt.Errorf("Tag 'block' takes exactly 1 argument (an identifier)."), nil)
 	}
 
 	wrapper, endtagargs, err := doc.WrapUntilTag("endblock")
@@ -100,13 +100,13 @@ func tagBlockParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Er
 		endtagnameToken := endtagargs.MatchType(TokenIdentifier)
 		if endtagnameToken != nil {
 			if endtagnameToken.Val != nameToken.Val {
-				return nil, endtagargs.Error(fmt.Sprintf("Name for 'endblock' must equal to 'block'-tag's name ('%s' != '%s').",
+				return nil, endtagargs.Error(fmt.Errorf("Name for 'endblock' must equal to 'block'-tag's name ('%s' != '%s').",
 					nameToken.Val, endtagnameToken.Val), nil)
 			}
 		}
 
 		if endtagnameToken == nil || endtagargs.Remaining() > 0 {
-			return nil, endtagargs.Error("Either no or only one argument (identifier) allowed for 'endblock'.", nil)
+			return nil, endtagargs.Error(fmt.Errorf("Either no or only one argument (identifier) allowed for 'endblock'."), nil)
 		}
 	}
 
@@ -118,7 +118,7 @@ func tagBlockParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Er
 	if !hasBlock {
 		tpl.blocks[nameToken.Val] = wrapper
 	} else {
-		return nil, arguments.Error(fmt.Sprintf("Block named '%s' already defined", nameToken.Val), nil)
+		return nil, arguments.Error(fmt.Errorf("Block named '%s' already defined", nameToken.Val), nil)
 	}
 
 	return &tagBlockNode{name: nameToken.Val}, nil

--- a/tags_comment.go
+++ b/tags_comment.go
@@ -1,5 +1,7 @@
 package pongo2
 
+import "fmt"
+
 type tagCommentNode struct{}
 
 func (node *tagCommentNode) Execute(ctx *ExecutionContext, writer TemplateWriter) *Error {
@@ -16,7 +18,7 @@ func tagCommentParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *
 	}
 
 	if arguments.Count() != 0 {
-		return nil, arguments.Error("Tag 'comment' does not take any argument.", nil)
+		return nil, arguments.Error(fmt.Errorf("Tag 'comment' does not take any argument."), nil)
 	}
 
 	return commentNode, nil

--- a/tags_cycle.go
+++ b/tags_cycle.go
@@ -1,5 +1,7 @@
 package pongo2
 
+import "fmt"
+
 type tagCycleValue struct {
 	node  *tagCycleNode
 	value *Value
@@ -81,7 +83,7 @@ func tagCycleParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Er
 
 			nameToken := arguments.MatchType(TokenIdentifier)
 			if nameToken == nil {
-				return nil, arguments.Error("Name (identifier) expected after 'as'.", nil)
+				return nil, arguments.Error(fmt.Errorf("Name (identifier) expected after 'as'."), nil)
 			}
 			cycleNode.asName = nameToken.Val
 
@@ -95,7 +97,7 @@ func tagCycleParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Er
 	}
 
 	if arguments.Remaining() > 0 {
-		return nil, arguments.Error("Malformed cycle-tag.", nil)
+		return nil, arguments.Error(fmt.Errorf("Malformed cycle-tag."), nil)
 	}
 
 	return cycleNode, nil

--- a/tags_extends.go
+++ b/tags_extends.go
@@ -1,5 +1,7 @@
 package pongo2
 
+import "fmt"
+
 type tagExtendsNode struct {
 	filename string
 }
@@ -12,12 +14,12 @@ func tagExtendsParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *
 	extendsNode := &tagExtendsNode{}
 
 	if doc.template.level > 1 {
-		return nil, arguments.Error("The 'extends' tag can only defined on root level.", start)
+		return nil, arguments.Error(fmt.Errorf("The 'extends' tag can only defined on root level."), start)
 	}
 
 	if doc.template.parent != nil {
 		// Already one parent
-		return nil, arguments.Error("This template has already one parent.", start)
+		return nil, arguments.Error(fmt.Errorf("This template has already one parent."), start)
 	}
 
 	if filenameToken := arguments.MatchType(TokenString); filenameToken != nil {
@@ -37,11 +39,11 @@ func tagExtendsParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *
 		doc.template.parent = parentTemplate
 		extendsNode.filename = parentFilename
 	} else {
-		return nil, arguments.Error("Tag 'extends' requires a template filename as string.", nil)
+		return nil, arguments.Error(fmt.Errorf("Tag 'extends' requires a template filename as string."), nil)
 	}
 
 	if arguments.Remaining() > 0 {
-		return nil, arguments.Error("Tag 'extends' does only take 1 argument.", nil)
+		return nil, arguments.Error(fmt.Errorf("Tag 'extends' does only take 1 argument."), nil)
 	}
 
 	return extendsNode, nil

--- a/tags_filter.go
+++ b/tags_filter.go
@@ -2,6 +2,7 @@ package pongo2
 
 import (
 	"bytes"
+	"fmt"
 )
 
 type nodeFilterCall struct {
@@ -37,7 +38,7 @@ func (node *tagFilterNode) Execute(ctx *ExecutionContext, writer TemplateWriter)
 		}
 		value, err = ApplyFilter(call.name, value, param)
 		if err != nil {
-			return ctx.Error(err.Error(), node.position)
+			return ctx.Error(err, node.position)
 		}
 	}
 
@@ -62,7 +63,7 @@ func tagFilterParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *E
 
 		nameToken := arguments.MatchType(TokenIdentifier)
 		if nameToken == nil {
-			return nil, arguments.Error("Expected a filter name (identifier).", nil)
+			return nil, arguments.Error(fmt.Errorf("Expected a filter name (identifier)."), nil)
 		}
 		filterCall.name = nameToken.Val
 
@@ -84,7 +85,7 @@ func tagFilterParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *E
 	}
 
 	if arguments.Remaining() > 0 {
-		return nil, arguments.Error("Malformed filter-tag arguments.", nil)
+		return nil, arguments.Error(fmt.Errorf("Malformed filter-tag arguments."), nil)
 	}
 
 	return filterNode, nil

--- a/tags_for.go
+++ b/tags_for.go
@@ -1,5 +1,7 @@
 package pongo2
 
+import "fmt"
+
 type tagForNode struct {
 	key             string
 	value           string // only for maps: for key, value in map
@@ -90,19 +92,19 @@ func tagForParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Erro
 	var valueToken *Token
 	keyToken := arguments.MatchType(TokenIdentifier)
 	if keyToken == nil {
-		return nil, arguments.Error("Expected an key identifier as first argument for 'for'-tag", nil)
+		return nil, arguments.Error(fmt.Errorf("Expected an key identifier as first argument for 'for'-tag"), nil)
 	}
 
 	if arguments.Match(TokenSymbol, ",") != nil {
 		// Value name is provided
 		valueToken = arguments.MatchType(TokenIdentifier)
 		if valueToken == nil {
-			return nil, arguments.Error("Value name must be an identifier.", nil)
+			return nil, arguments.Error(fmt.Errorf("Value name must be an identifier."), nil)
 		}
 	}
 
 	if arguments.Match(TokenKeyword, "in") == nil {
-		return nil, arguments.Error("Expected keyword 'in'.", nil)
+		return nil, arguments.Error(fmt.Errorf("Expected keyword 'in'."), nil)
 	}
 
 	objectEvaluator, err := arguments.ParseExpression()
@@ -124,7 +126,7 @@ func tagForParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Erro
 	}
 
 	if arguments.Remaining() > 0 {
-		return nil, arguments.Error("Malformed for-loop arguments.", nil)
+		return nil, arguments.Error(fmt.Errorf("Malformed for-loop arguments."), nil)
 	}
 
 	// Body wrapping
@@ -135,7 +137,7 @@ func tagForParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Erro
 	forNode.bodyWrapper = wrapper
 
 	if endargs.Count() > 0 {
-		return nil, endargs.Error("Arguments not allowed here.", nil)
+		return nil, endargs.Error(fmt.Errorf("Arguments not allowed here."), nil)
 	}
 
 	if wrapper.Endtag == "empty" {
@@ -147,7 +149,7 @@ func tagForParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Erro
 		forNode.emptyWrapper = wrapper
 
 		if endargs.Count() > 0 {
-			return nil, endargs.Error("Arguments not allowed here.", nil)
+			return nil, endargs.Error(fmt.Errorf("Arguments not allowed here."), nil)
 		}
 	}
 

--- a/tags_if.go
+++ b/tags_if.go
@@ -1,5 +1,7 @@
 package pongo2
 
+import "fmt"
+
 type tagIfNode struct {
 	conditions []IEvaluator
 	wrappers   []*NodeWrapper
@@ -34,7 +36,7 @@ func tagIfParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Error
 	ifNode.conditions = append(ifNode.conditions, condition)
 
 	if arguments.Remaining() > 0 {
-		return nil, arguments.Error("If-condition is malformed.", nil)
+		return nil, arguments.Error(fmt.Errorf("If-condition is malformed."), nil)
 	}
 
 	// Check the rest
@@ -54,12 +56,12 @@ func tagIfParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Error
 			ifNode.conditions = append(ifNode.conditions, condition)
 
 			if tagArgs.Remaining() > 0 {
-				return nil, tagArgs.Error("Elif-condition is malformed.", nil)
+				return nil, tagArgs.Error(fmt.Errorf("Elif-condition is malformed."), nil)
 			}
 		} else {
 			if tagArgs.Count() > 0 {
 				// else/endif can't take any conditions
-				return nil, tagArgs.Error("Arguments not allowed here.", nil)
+				return nil, tagArgs.Error(fmt.Errorf("Arguments not allowed here."), nil)
 			}
 		}
 

--- a/tags_ifchanged.go
+++ b/tags_ifchanged.go
@@ -2,6 +2,7 @@ package pongo2
 
 import (
 	"bytes"
+	"fmt"
 )
 
 type tagIfchangedNode struct {
@@ -83,7 +84,7 @@ func tagIfchangedParser(doc *Parser, start *Token, arguments *Parser) (INodeTag,
 	}
 
 	if arguments.Remaining() > 0 {
-		return nil, arguments.Error("Ifchanged-arguments are malformed.", nil)
+		return nil, arguments.Error(fmt.Errorf("Ifchanged-arguments are malformed."), nil)
 	}
 
 	// Wrap then/else-blocks
@@ -94,7 +95,7 @@ func tagIfchangedParser(doc *Parser, start *Token, arguments *Parser) (INodeTag,
 	ifchangedNode.thenWrapper = wrapper
 
 	if endargs.Count() > 0 {
-		return nil, endargs.Error("Arguments not allowed here.", nil)
+		return nil, endargs.Error(fmt.Errorf("Arguments not allowed here."), nil)
 	}
 
 	if wrapper.Endtag == "else" {
@@ -106,7 +107,7 @@ func tagIfchangedParser(doc *Parser, start *Token, arguments *Parser) (INodeTag,
 		ifchangedNode.elseWrapper = wrapper
 
 		if endargs.Count() > 0 {
-			return nil, endargs.Error("Arguments not allowed here.", nil)
+			return nil, endargs.Error(fmt.Errorf("Arguments not allowed here."), nil)
 		}
 	}
 

--- a/tags_ifequal.go
+++ b/tags_ifequal.go
@@ -1,5 +1,7 @@
 package pongo2
 
+import "fmt"
+
 type tagIfEqualNode struct {
 	var1, var2  IEvaluator
 	thenWrapper *NodeWrapper
@@ -43,7 +45,7 @@ func tagIfEqualParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *
 	ifequalNode.var2 = var2
 
 	if arguments.Remaining() > 0 {
-		return nil, arguments.Error("ifequal only takes 2 arguments.", nil)
+		return nil, arguments.Error(fmt.Errorf("ifequal only takes 2 arguments."), nil)
 	}
 
 	// Wrap then/else-blocks
@@ -54,7 +56,7 @@ func tagIfEqualParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *
 	ifequalNode.thenWrapper = wrapper
 
 	if endargs.Count() > 0 {
-		return nil, endargs.Error("Arguments not allowed here.", nil)
+		return nil, endargs.Error(fmt.Errorf("Arguments not allowed here."), nil)
 	}
 
 	if wrapper.Endtag == "else" {
@@ -66,7 +68,7 @@ func tagIfEqualParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *
 		ifequalNode.elseWrapper = wrapper
 
 		if endargs.Count() > 0 {
-			return nil, endargs.Error("Arguments not allowed here.", nil)
+			return nil, endargs.Error(fmt.Errorf("Arguments not allowed here."), nil)
 		}
 	}
 

--- a/tags_ifnotequal.go
+++ b/tags_ifnotequal.go
@@ -1,5 +1,7 @@
 package pongo2
 
+import "fmt"
+
 type tagIfNotEqualNode struct {
 	var1, var2  IEvaluator
 	thenWrapper *NodeWrapper
@@ -43,7 +45,7 @@ func tagIfNotEqualParser(doc *Parser, start *Token, arguments *Parser) (INodeTag
 	ifnotequalNode.var2 = var2
 
 	if arguments.Remaining() > 0 {
-		return nil, arguments.Error("ifequal only takes 2 arguments.", nil)
+		return nil, arguments.Error(fmt.Errorf("ifequal only takes 2 arguments."), nil)
 	}
 
 	// Wrap then/else-blocks
@@ -54,7 +56,7 @@ func tagIfNotEqualParser(doc *Parser, start *Token, arguments *Parser) (INodeTag
 	ifnotequalNode.thenWrapper = wrapper
 
 	if endargs.Count() > 0 {
-		return nil, endargs.Error("Arguments not allowed here.", nil)
+		return nil, endargs.Error(fmt.Errorf("Arguments not allowed here."), nil)
 	}
 
 	if wrapper.Endtag == "else" {
@@ -66,7 +68,7 @@ func tagIfNotEqualParser(doc *Parser, start *Token, arguments *Parser) (INodeTag
 		ifnotequalNode.elseWrapper = wrapper
 
 		if endargs.Count() > 0 {
-			return nil, endargs.Error("Arguments not allowed here.", nil)
+			return nil, endargs.Error(fmt.Errorf("Arguments not allowed here."), nil)
 		}
 	}
 

--- a/tags_import.go
+++ b/tags_import.go
@@ -29,13 +29,13 @@ func tagImportParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *E
 
 	filenameToken := arguments.MatchType(TokenString)
 	if filenameToken == nil {
-		return nil, arguments.Error("Import-tag needs a filename as string.", nil)
+		return nil, arguments.Error(fmt.Errorf("Import-tag needs a filename as string."), nil)
 	}
 
 	importNode.filename = doc.template.set.resolveFilename(doc.template, filenameToken.Val)
 
 	if arguments.Remaining() == 0 {
-		return nil, arguments.Error("You must at least specify one macro to import.", nil)
+		return nil, arguments.Error(fmt.Errorf("You must at least specify one macro to import."), nil)
 	}
 
 	// Compile the given template
@@ -47,21 +47,21 @@ func tagImportParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *E
 	for arguments.Remaining() > 0 {
 		macroNameToken := arguments.MatchType(TokenIdentifier)
 		if macroNameToken == nil {
-			return nil, arguments.Error("Expected macro name (identifier).", nil)
+			return nil, arguments.Error(fmt.Errorf("Expected macro name (identifier)."), nil)
 		}
 
 		asName := macroNameToken.Val
 		if arguments.Match(TokenKeyword, "as") != nil {
 			aliasToken := arguments.MatchType(TokenIdentifier)
 			if aliasToken == nil {
-				return nil, arguments.Error("Expected macro alias name (identifier).", nil)
+				return nil, arguments.Error(fmt.Errorf("Expected macro alias name (identifier)."), nil)
 			}
 			asName = aliasToken.Val
 		}
 
 		macroInstance, has := tpl.exportedMacros[macroNameToken.Val]
 		if !has {
-			return nil, arguments.Error(fmt.Sprintf("Macro '%s' not found (or not exported) in '%s'.", macroNameToken.Val,
+			return nil, arguments.Error(fmt.Errorf("Macro '%s' not found (or not exported) in '%s'.", macroNameToken.Val,
 				importNode.filename), macroNameToken)
 		}
 
@@ -72,7 +72,7 @@ func tagImportParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *E
 		}
 
 		if arguments.Match(TokenSymbol, ",") == nil {
-			return nil, arguments.Error("Expected ','.", nil)
+			return nil, arguments.Error(fmt.Errorf("Expected ','."), nil)
 		}
 	}
 

--- a/tags_include.go
+++ b/tags_include.go
@@ -1,5 +1,7 @@
 package pongo2
 
+import "fmt"
+
 type tagIncludeNode struct {
 	tpl               *Template
 	filenameEvaluator IEvaluator
@@ -38,7 +40,7 @@ func (node *tagIncludeNode) Execute(ctx *ExecutionContext, writer TemplateWriter
 		}
 
 		if filename.String() == "" {
-			return ctx.Error("Filename for 'include'-tag evaluated to an empty string.", nil)
+			return ctx.Error(fmt.Errorf("Filename for 'include'-tag evaluated to an empty string."), nil)
 		}
 
 		// Get include-filename
@@ -114,10 +116,10 @@ func tagIncludeParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *
 			// We have at least one key=expr pair (because of starting "with")
 			keyToken := arguments.MatchType(TokenIdentifier)
 			if keyToken == nil {
-				return nil, arguments.Error("Expected an identifier", nil)
+				return nil, arguments.Error(fmt.Errorf("Expected an identifier"), nil)
 			}
 			if arguments.Match(TokenSymbol, "=") == nil {
-				return nil, arguments.Error("Expected '='.", nil)
+				return nil, arguments.Error(fmt.Errorf("Expected '='."), nil)
 			}
 			valueExpr, err := arguments.ParseExpression()
 			if err != nil {
@@ -135,7 +137,7 @@ func tagIncludeParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *
 	}
 
 	if arguments.Remaining() > 0 {
-		return nil, arguments.Error("Malformed 'include'-tag arguments.", nil)
+		return nil, arguments.Error(fmt.Errorf("Malformed 'include'-tag arguments."), nil)
 	}
 
 	return includeNode, nil

--- a/tags_lorem.go
+++ b/tags_lorem.go
@@ -23,7 +23,7 @@ type tagLoremNode struct {
 
 func (node *tagLoremNode) Execute(ctx *ExecutionContext, writer TemplateWriter) *Error {
 	if node.count > maxLoremCount {
-		return ctx.Error(fmt.Sprintf("max count for lorem is %d", maxLoremCount), node.position)
+		return ctx.Error(fmt.Errorf("max count for lorem is %d", maxLoremCount), node.position)
 	}
 
 	switch node.method {
@@ -106,7 +106,7 @@ func tagLoremParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Er
 
 	if methodToken := arguments.MatchType(TokenIdentifier); methodToken != nil {
 		if methodToken.Val != "w" && methodToken.Val != "p" && methodToken.Val != "b" {
-			return nil, arguments.Error("lorem-method must be either 'w', 'p' or 'b'.", nil)
+			return nil, arguments.Error(fmt.Errorf("lorem-method must be either 'w', 'p' or 'b'."), nil)
 		}
 
 		loremNode.method = methodToken.Val
@@ -117,7 +117,7 @@ func tagLoremParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Er
 	}
 
 	if arguments.Remaining() > 0 {
-		return nil, arguments.Error("Malformed lorem-tag arguments.", nil)
+		return nil, arguments.Error(fmt.Errorf("Malformed lorem-tag arguments."), nil)
 	}
 
 	return loremNode, nil

--- a/tags_now.go
+++ b/tags_now.go
@@ -1,6 +1,7 @@
 package pongo2
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -30,7 +31,7 @@ func tagNowParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Erro
 
 	formatToken := arguments.MatchType(TokenString)
 	if formatToken == nil {
-		return nil, arguments.Error("Expected a format string.", nil)
+		return nil, arguments.Error(fmt.Errorf("Expected a format string."), nil)
 	}
 	nowNode.format = formatToken.Val
 
@@ -39,7 +40,7 @@ func tagNowParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Erro
 	}
 
 	if arguments.Remaining() > 0 {
-		return nil, arguments.Error("Malformed now-tag arguments.", nil)
+		return nil, arguments.Error(fmt.Errorf("Malformed now-tag arguments."), nil)
 	}
 
 	return nowNode, nil

--- a/tags_set.go
+++ b/tags_set.go
@@ -1,5 +1,7 @@
 package pongo2
 
+import "fmt"
+
 type tagSetNode struct {
 	name       string
 	expression IEvaluator
@@ -22,12 +24,12 @@ func tagSetParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Erro
 	// Parse variable name
 	typeToken := arguments.MatchType(TokenIdentifier)
 	if typeToken == nil {
-		return nil, arguments.Error("Expected an identifier.", nil)
+		return nil, arguments.Error(fmt.Errorf("Expected an identifier."), nil)
 	}
 	node.name = typeToken.Val
 
 	if arguments.Match(TokenSymbol, "=") == nil {
-		return nil, arguments.Error("Expected '='.", nil)
+		return nil, arguments.Error(fmt.Errorf("Expected '='."), nil)
 	}
 
 	// Variable expression
@@ -39,7 +41,7 @@ func tagSetParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Erro
 
 	// Remaining arguments
 	if arguments.Remaining() > 0 {
-		return nil, arguments.Error("Malformed 'set'-tag arguments.", nil)
+		return nil, arguments.Error(fmt.Errorf("Malformed 'set'-tag arguments."), nil)
 	}
 
 	return node, nil

--- a/tags_spaceless.go
+++ b/tags_spaceless.go
@@ -2,6 +2,7 @@ package pongo2
 
 import (
 	"bytes"
+	"fmt"
 	"regexp"
 )
 
@@ -43,7 +44,7 @@ func tagSpacelessParser(doc *Parser, start *Token, arguments *Parser) (INodeTag,
 	spacelessNode.wrapper = wrapper
 
 	if arguments.Remaining() > 0 {
-		return nil, arguments.Error("Malformed spaceless-tag arguments.", nil)
+		return nil, arguments.Error(fmt.Errorf("Malformed spaceless-tag arguments."), nil)
 	}
 
 	return spacelessNode, nil

--- a/tags_ssi.go
+++ b/tags_ssi.go
@@ -1,6 +1,7 @@
 package pongo2
 
 import (
+	"fmt"
 	"io/ioutil"
 )
 
@@ -53,11 +54,11 @@ func tagSSIParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Erro
 			SSINode.content = string(buf)
 		}
 	} else {
-		return nil, arguments.Error("First argument must be a string.", nil)
+		return nil, arguments.Error(fmt.Errorf("First argument must be a string."), nil)
 	}
 
 	if arguments.Remaining() > 0 {
-		return nil, arguments.Error("Malformed SSI-tag argument.", nil)
+		return nil, arguments.Error(fmt.Errorf("Malformed SSI-tag argument."), nil)
 	}
 
 	return SSINode, nil

--- a/tags_templatetag.go
+++ b/tags_templatetag.go
@@ -1,5 +1,7 @@
 package pongo2
 
+import "fmt"
+
 type tagTemplateTagNode struct {
 	content string
 }
@@ -26,15 +28,15 @@ func tagTemplateTagParser(doc *Parser, start *Token, arguments *Parser) (INodeTa
 	if argToken := arguments.MatchType(TokenIdentifier); argToken != nil {
 		output, found := templateTagMapping[argToken.Val]
 		if !found {
-			return nil, arguments.Error("Argument not found", argToken)
+			return nil, arguments.Error(fmt.Errorf("Argument not found"), argToken)
 		}
 		ttNode.content = output
 	} else {
-		return nil, arguments.Error("Identifier expected.", nil)
+		return nil, arguments.Error(fmt.Errorf("Identifier expected."), nil)
 	}
 
 	if arguments.Remaining() > 0 {
-		return nil, arguments.Error("Malformed templatetag-tag argument.", nil)
+		return nil, arguments.Error(fmt.Errorf("Malformed templatetag-tag argument."), nil)
 	}
 
 	return ttNode, nil

--- a/tags_widthratio.go
+++ b/tags_widthratio.go
@@ -66,13 +66,13 @@ func tagWidthratioParser(doc *Parser, start *Token, arguments *Parser) (INodeTag
 		// Name follows
 		nameToken := arguments.MatchType(TokenIdentifier)
 		if nameToken == nil {
-			return nil, arguments.Error("Expected name (identifier).", nil)
+			return nil, arguments.Error(fmt.Errorf("Expected name (identifier)."), nil)
 		}
 		widthratioNode.ctxName = nameToken.Val
 	}
 
 	if arguments.Remaining() > 0 {
-		return nil, arguments.Error("Malformed widthratio-tag arguments.", nil)
+		return nil, arguments.Error(fmt.Errorf("Malformed widthratio-tag arguments."), nil)
 	}
 
 	return widthratioNode, nil

--- a/tags_with.go
+++ b/tags_with.go
@@ -1,5 +1,7 @@
 package pongo2
 
+import "fmt"
+
 type tagWithNode struct {
 	withPairs map[string]IEvaluator
 	wrapper   *NodeWrapper
@@ -27,7 +29,7 @@ func tagWithParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Err
 	}
 
 	if arguments.Count() == 0 {
-		return nil, arguments.Error("Tag 'with' requires at least one argument.", nil)
+		return nil, arguments.Error(fmt.Errorf("Tag 'with' requires at least one argument."), nil)
 	}
 
 	wrapper, endargs, err := doc.WrapUntilTag("endwith")
@@ -37,7 +39,7 @@ func tagWithParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Err
 	withNode.wrapper = wrapper
 
 	if endargs.Count() > 0 {
-		return nil, endargs.Error("Arguments not allowed here.", nil)
+		return nil, endargs.Error(fmt.Errorf("Arguments not allowed here."), nil)
 	}
 
 	// Scan through all arguments to see which style the user uses (old or new style).
@@ -57,20 +59,20 @@ func tagWithParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Err
 				return nil, err
 			}
 			if arguments.Match(TokenKeyword, "as") == nil {
-				return nil, arguments.Error("Expected 'as' keyword.", nil)
+				return nil, arguments.Error(fmt.Errorf("Expected 'as' keyword."), nil)
 			}
 			keyToken := arguments.MatchType(TokenIdentifier)
 			if keyToken == nil {
-				return nil, arguments.Error("Expected an identifier", nil)
+				return nil, arguments.Error(fmt.Errorf("Expected an identifier"), nil)
 			}
 			withNode.withPairs[keyToken.Val] = valueExpr
 		} else {
 			keyToken := arguments.MatchType(TokenIdentifier)
 			if keyToken == nil {
-				return nil, arguments.Error("Expected an identifier", nil)
+				return nil, arguments.Error(fmt.Errorf("Expected an identifier"), nil)
 			}
 			if arguments.Match(TokenSymbol, "=") == nil {
-				return nil, arguments.Error("Expected '='.", nil)
+				return nil, arguments.Error(fmt.Errorf("Expected '='."), nil)
 			}
 			valueExpr, err := arguments.ParseExpression()
 			if err != nil {

--- a/variable.go
+++ b/variable.go
@@ -488,7 +488,7 @@ func (vr *variableResolver) resolve(ctx *ExecutionContext) (*Value, error) {
 func (vr *variableResolver) Evaluate(ctx *ExecutionContext) (*Value, *Error) {
 	value, err := vr.resolve(ctx)
 	if err != nil {
-		return AsValue(nil), ctx.Error(err.Error(), vr.locationToken)
+		return AsValue(nil), ctx.Error(err, vr.locationToken)
 	}
 	return value, nil
 }
@@ -523,7 +523,7 @@ func (p *Parser) parseVariableOrLiteral() (IEvaluator, *Error) {
 	t := p.Current()
 
 	if t == nil {
-		return nil, p.Error("Unexpected EOF, expected a number, string, keyword or identifier.", p.lastToken)
+		return nil, p.Error(fmt.Errorf("Unexpected EOF, expected a number, string, keyword or identifier."), p.lastToken)
 	}
 
 	// Is first part a number or a string, there's nothing to resolve (because there's only to return the value then)
@@ -540,11 +540,11 @@ func (p *Parser) parseVariableOrLiteral() (IEvaluator, *Error) {
 			// float64
 			t2 := p.MatchType(TokenNumber)
 			if t2 == nil {
-				return nil, p.Error("Expected a number after the '.'.", nil)
+				return nil, p.Error(fmt.Errorf("Expected a number after the '.'."), nil)
 			}
 			f, err := strconv.ParseFloat(fmt.Sprintf("%s.%s", t.Val, t2.Val), 64)
 			if err != nil {
-				return nil, p.Error(err.Error(), t)
+				return nil, p.Error(err, t)
 			}
 			fr := &floatResolver{
 				locationToken: t,
@@ -554,7 +554,7 @@ func (p *Parser) parseVariableOrLiteral() (IEvaluator, *Error) {
 		}
 		i, err := strconv.Atoi(t.Val)
 		if err != nil {
-			return nil, p.Error(err.Error(), t)
+			return nil, p.Error(err, t)
 		}
 		nr := &intResolver{
 			locationToken: t,
@@ -585,7 +585,7 @@ func (p *Parser) parseVariableOrLiteral() (IEvaluator, *Error) {
 			}
 			return br, nil
 		default:
-			return nil, p.Error("This keyword is not allowed here.", nil)
+			return nil, p.Error(fmt.Errorf("This keyword is not allowed here."), nil)
 		}
 	}
 
@@ -595,7 +595,7 @@ func (p *Parser) parseVariableOrLiteral() (IEvaluator, *Error) {
 
 	// First part of a variable MUST be an identifier
 	if t.Typ != TokenIdentifier {
-		return nil, p.Error("Expected either a number, string, keyword or identifier.", t)
+		return nil, p.Error(fmt.Errorf("Expected either a number, string, keyword or identifier."), t)
 	}
 
 	resolver.parts = append(resolver.parts, &variablePart{
@@ -624,7 +624,7 @@ variableLoop:
 				case TokenNumber:
 					i, err := strconv.Atoi(t2.Val)
 					if err != nil {
-						return nil, p.Error(err.Error(), t2)
+						return nil, p.Error(err, t2)
 					}
 					resolver.parts = append(resolver.parts, &variablePart{
 						typ: varTypeInt,
@@ -640,17 +640,17 @@ variableLoop:
 					p.Consume() // consume: NIL
 					continue variableLoop
 				default:
-					return nil, p.Error("This token is not allowed within a variable name.", t2)
+					return nil, p.Error(fmt.Errorf("This token is not allowed within a variable name."), t2)
 				}
 			} else {
 				// EOF
-				return nil, p.Error("Unexpected EOF, expected either IDENTIFIER or NUMBER after DOT.",
+				return nil, p.Error(fmt.Errorf("Unexpected EOF, expected either IDENTIFIER or NUMBER after DOT."),
 					p.lastToken)
 			}
 		} else if p.Match(TokenSymbol, "[") != nil {
 			// Variable subscript
 			if p.Remaining() == 0 {
-				return nil, p.Error("Unexpected EOF, expected subscript subscript.", p.lastToken)
+				return nil, p.Error(fmt.Errorf("Unexpected EOF, expected subscript subscript."), p.lastToken)
 			}
 			exprSubscript, err := p.ParseExpression()
 			if err != nil {
@@ -661,7 +661,7 @@ variableLoop:
 				subscript: exprSubscript,
 			})
 			if p.Match(TokenSymbol, "]") == nil {
-				return nil, p.Error("Missing closing bracket after subscript argument.", nil)
+				return nil, p.Error(fmt.Errorf("Missing closing bracket after subscript argument."), nil)
 			}
 		} else if p.Match(TokenSymbol, "(") != nil {
 			// Function call
@@ -671,7 +671,7 @@ variableLoop:
 		argumentLoop:
 			for {
 				if p.Remaining() == 0 {
-					return nil, p.Error("Unexpected EOF, expected function call argument list.", p.lastToken)
+					return nil, p.Error(fmt.Errorf("Unexpected EOF, expected function call argument list."), p.lastToken)
 				}
 
 				if p.Peek(TokenSymbol, ")") == nil {
@@ -688,7 +688,7 @@ variableLoop:
 					} else {
 						// If there's NO closing bracket, there MUST be an comma
 						if p.Match(TokenSymbol, ",") == nil {
-							return nil, p.Error("Missing comma or closing bracket after argument.", nil)
+							return nil, p.Error(fmt.Errorf("Missing comma or closing bracket after argument."), nil)
 						}
 					}
 				} else {
@@ -732,7 +732,7 @@ filterLoop:
 
 		// Check sandbox filter restriction
 		if _, isBanned := p.template.set.bannedFilters[filter.name]; isBanned {
-			return nil, p.Error(fmt.Sprintf("Usage of filter '%s' is not allowed (sandbox restriction active).", filter.name), nil)
+			return nil, p.Error(fmt.Errorf("Usage of filter '%s' is not allowed (sandbox restriction active).", filter.name), nil)
 		}
 
 		v.filterChain = append(v.filterChain, filter)
@@ -757,7 +757,7 @@ func (p *Parser) parseVariableElement() (INode, *Error) {
 	node.expr = expr
 
 	if p.Match(TokenSymbol, "}}") == nil {
-		return nil, p.Error("'}}' expected", nil)
+		return nil, p.Error(fmt.Errorf("'}}' expected"), nil)
 	}
 
 	return node, nil


### PR DESCRIPTION
## Description of the change

pongo2 was converting the error to string, so detecting any other custom error was impossible. With these changes, we can detect custom errors.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
