### PR TITLE
feat: unwrap function to support errors.as

### DIFF
--- a/error.go
+++ b/error.go
@@ -89,3 +89,7 @@ func (e *Error) RawLine() (line string, available bool, outErr error) {
 	}
 	return "", false, nil
 }
+
+func (e *Error) Unwrap() error {
+	return e.OrigError
+}


### PR DESCRIPTION
## Description of the change

Errors.As internally calls `interface.Unwrap()` , implemented pongo2 error Unwrap function to support Errors.Is and Errors.As without calling the unwrap function from wht.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
