### PR TITLE
fix: allow concurrent read/write access of Context struct

### DIFF
--- a/pongo2_issues_test.go
+++ b/pongo2_issues_test.go
@@ -6,19 +6,27 @@ import (
 	"github.com/flosch/pongo2/v6"
 )
 
+func createContext(mapInput map[string]any) *pongo2.Context {
+	result := pongo2.NewContext()
+	for k, v := range mapInput {
+		result.Set(k, v)
+	}
+	return result
+}
+
 func TestIssue151(t *testing.T) {
 	tpl, err := pongo2.FromString("{{ mydict.51232_3 }}{{ 12345_123}}{{ 995189baz }}")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	str, err := tpl.Execute(pongo2.Context{
+	str, err := tpl.Execute(createContext(map[string]any{
 		"mydict": map[string]string{
 			"51232_3": "foo",
 		},
 		"12345_123": "bar",
 		"995189baz": "baz",
-	})
+	}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,7 +42,7 @@ func TestIssue297(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	str, err := tpl.Execute(pongo2.Context{"input": "one two three four five six"})
+	str, err := tpl.Execute(createContext(map[string]any{"input": "one two three four five six"}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/syncMap.go
+++ b/syncMap.go
@@ -1,0 +1,39 @@
+package pongo2
+
+import (
+	"sync"
+)
+
+// Generic map wrapper with locking support
+type SyncMap[K comparable, V any] struct {
+	m    map[K]V
+	lock sync.RWMutex
+}
+
+func NewSyncMap[K comparable, V any]() *SyncMap[K, V] {
+	return &SyncMap[K, V]{
+		m:    make(map[K]V),
+		lock: sync.RWMutex{},
+	}
+}
+
+func (sm *SyncMap[K, V]) Get(key K) (V, bool) {
+	sm.lock.RLock()
+	defer sm.lock.RUnlock()
+	val, ok := sm.m[key]
+	return val, ok
+}
+
+func (sm *SyncMap[K, V]) Set(key K, value V) {
+	sm.lock.Lock()
+	defer sm.lock.Unlock()
+	sm.m[key] = value
+}
+
+func (sm *SyncMap[K, V]) Entries() map[K]V {
+	result := make(map[K]V)
+	for k, v := range sm.m {
+		result[k] = v
+	}
+	return result
+}

--- a/syncMap.go
+++ b/syncMap.go
@@ -37,3 +37,7 @@ func (sm *SyncMap[K, V]) Entries() map[K]V {
 	}
 	return result
 }
+
+func (sm *SyncMap[K, V]) Length() int {
+	return len(sm.m)
+}

--- a/tags_block.go
+++ b/tags_block.go
@@ -39,10 +39,10 @@ func (node *tagBlockNode) Execute(ctx *ExecutionContext, writer TemplateWriter) 
 	}
 
 	blockWrapper := blockWrappers[lenBlockWrappers-1]
-	ctx.Private["block"] = tagBlockInformation{
+	ctx.Private.Set("block", tagBlockInformation{
 		ctx:      ctx,
 		wrappers: blockWrappers[0 : lenBlockWrappers-1],
-	}
+	})
 	err := blockWrapper.Execute(ctx, writer)
 	if err != nil {
 		return err
@@ -64,10 +64,10 @@ func (t tagBlockInformation) Super() (*Value, error) {
 	}
 
 	superCtx := NewChildExecutionContext(t.ctx)
-	superCtx.Private["block"] = tagBlockInformation{
+	superCtx.Private.Set("block", tagBlockInformation{
 		ctx:      t.ctx,
 		wrappers: t.wrappers[0 : lenWrappers-1],
-	}
+	})
 
 	blockWrapper := t.wrappers[lenWrappers-1]
 	buf := bytes.NewBufferString("")

--- a/tags_cycle.go
+++ b/tags_cycle.go
@@ -55,7 +55,7 @@ func (node *tagCycleNode) Execute(ctx *ExecutionContext, writer TemplateWriter) 
 		}
 
 		if node.asName != "" {
-			ctx.Private[node.asName] = cycleValue
+			ctx.Private.Set(node.asName, cycleValue)
 		}
 		if !node.silent {
 			writer.WriteString(val.String())

--- a/tags_for.go
+++ b/tags_for.go
@@ -26,7 +26,7 @@ type tagForLoopInformation struct {
 func (node *tagForNode) Execute(ctx *ExecutionContext, writer TemplateWriter) (forError *Error) {
 	// Backup forloop (as parentloop in public context), key-name and value-name
 	forCtx := NewChildExecutionContext(ctx)
-	parentloop := forCtx.Private["forloop"]
+	parentloop, _ := forCtx.Private.Get("forloop")
 
 	// Create loop struct
 	loopInfo := &tagForLoopInformation{
@@ -39,7 +39,7 @@ func (node *tagForNode) Execute(ctx *ExecutionContext, writer TemplateWriter) (f
 	}
 
 	// Register loopInfo in public context
-	forCtx.Private["forloop"] = loopInfo
+	forCtx.Private.Set("forloop", loopInfo)
 
 	obj, err := node.objectEvaluator.Evaluate(forCtx)
 	if err != nil {
@@ -50,9 +50,9 @@ func (node *tagForNode) Execute(ctx *ExecutionContext, writer TemplateWriter) (f
 		// There's something to iterate over (correct type and at least 1 item)
 
 		// Update loop infos and public context
-		forCtx.Private[node.key] = key
+		forCtx.Private.Set(node.key, key)
 		if value != nil {
-			forCtx.Private[node.value] = value
+			forCtx.Private.Set(node.value, value)
 		}
 		loopInfo.Counter = idx + 1
 		loopInfo.Counter0 = idx

--- a/tags_import.go
+++ b/tags_import.go
@@ -13,9 +13,9 @@ type tagImportNode struct {
 func (node *tagImportNode) Execute(ctx *ExecutionContext, writer TemplateWriter) *Error {
 	for name, macro := range node.macros {
 		func(name string, macro *tagMacroNode) {
-			ctx.Private[name] = func(args ...*Value) (*Value, error) {
+			ctx.Private.Set(name, func(args ...*Value) (*Value, error) {
 				return macro.call(ctx, args...)
-			}
+			})
 		}(name, macro)
 	}
 	return nil

--- a/tags_include.go
+++ b/tags_include.go
@@ -14,7 +14,7 @@ type tagIncludeNode struct {
 
 func (node *tagIncludeNode) Execute(ctx *ExecutionContext, writer TemplateWriter) *Error {
 	// Building the context for the template
-	includeCtx := make(Context)
+	includeCtx := NewContext()
 
 	// Fill the context with all data from the parent
 	if !node.only {
@@ -28,7 +28,7 @@ func (node *tagIncludeNode) Execute(ctx *ExecutionContext, writer TemplateWriter
 		if err != nil {
 			return err
 		}
-		includeCtx[key] = val
+		includeCtx.Set(key, val)
 	}
 
 	// Execute the template

--- a/tags_set.go
+++ b/tags_set.go
@@ -14,7 +14,7 @@ func (node *tagSetNode) Execute(ctx *ExecutionContext, writer TemplateWriter) *E
 		return err
 	}
 
-	ctx.Private[node.name] = value
+	ctx.Private.Set(node.name, value)
 	return nil
 }
 

--- a/tags_ssi.go
+++ b/tags_ssi.go
@@ -16,7 +16,7 @@ type tagSSINode struct {
 func (node *tagSSINode) Execute(ctx *ExecutionContext, writer TemplateWriter) *Error {
 	if node.template != nil {
 		// Execute the template within the current context
-		includeCtx := make(Context)
+		includeCtx := NewContext()
 		includeCtx.Update(ctx.Public)
 		includeCtx.Update(ctx.Private)
 

--- a/tags_widthratio.go
+++ b/tags_widthratio.go
@@ -33,7 +33,7 @@ func (node *tagWidthratioNode) Execute(ctx *ExecutionContext, writer TemplateWri
 	if node.ctxName == "" {
 		writer.WriteString(fmt.Sprintf("%d", value))
 	} else {
-		ctx.Private[node.ctxName] = value
+		ctx.Private.Set(node.ctxName, value)
 	}
 
 	return nil

--- a/tags_with.go
+++ b/tags_with.go
@@ -17,7 +17,7 @@ func (node *tagWithNode) Execute(ctx *ExecutionContext, writer TemplateWriter) *
 		if err != nil {
 			return err
 		}
-		withctx.Private[key] = val
+		withctx.Private.Set(key, val)
 	}
 
 	return node.wrapper.Execute(withctx, writer)

--- a/template_sets.go
+++ b/template_sets.go
@@ -29,7 +29,7 @@ type TemplateSet struct {
 	loaders []TemplateLoader
 
 	// Globals will be provided to all templates created within this template set
-	Globals Context
+	Globals *Context
 
 	// If debug is true (default false), ExecutionContext.Logf() will work and output
 	// to STDOUT. Furthermore, FromCache() won't cache the templates.
@@ -67,7 +67,7 @@ func NewSet(name string, loaders ...TemplateLoader) *TemplateSet {
 	return &TemplateSet{
 		name:          name,
 		loaders:       loaders,
-		Globals:       make(Context),
+		Globals:       NewContext(),
 		bannedTags:    make(map[string]bool),
 		bannedFilters: make(map[string]bool),
 		templateCache: make(map[string]*Template),
@@ -231,7 +231,7 @@ func (set *TemplateSet) FromFile(filename string) (*Template, error) {
 }
 
 // RenderTemplateString is a shortcut and renders a template string directly.
-func (set *TemplateSet) RenderTemplateString(s string, ctx Context) (string, error) {
+func (set *TemplateSet) RenderTemplateString(s string, ctx *Context) (string, error) {
 	set.firstTemplateCreated = true
 
 	tpl := Must(set.FromString(s))
@@ -243,7 +243,7 @@ func (set *TemplateSet) RenderTemplateString(s string, ctx Context) (string, err
 }
 
 // RenderTemplateBytes is a shortcut and renders template bytes directly.
-func (set *TemplateSet) RenderTemplateBytes(b []byte, ctx Context) (string, error) {
+func (set *TemplateSet) RenderTemplateBytes(b []byte, ctx *Context) (string, error) {
 	set.firstTemplateCreated = true
 
 	tpl := Must(set.FromBytes(b))
@@ -255,7 +255,7 @@ func (set *TemplateSet) RenderTemplateBytes(b []byte, ctx Context) (string, erro
 }
 
 // RenderTemplateFile is a shortcut and renders a template file directly.
-func (set *TemplateSet) RenderTemplateFile(fn string, ctx Context) (string, error) {
+func (set *TemplateSet) RenderTemplateFile(fn string, ctx *Context) (string, error) {
 	set.firstTemplateCreated = true
 
 	tpl := Must(set.FromFile(fn))

--- a/variable.go
+++ b/variable.go
@@ -276,11 +276,11 @@ func (vr *variableResolver) resolve(ctx *ExecutionContext) (*Value, error) {
 			// We're looking up the first part of the variable.
 			// First we're having a look in our private
 			// context (e. g. information provided by tags, like the forloop)
-			val, inPrivate := ctx.Private[vr.parts[0].s]
+			val, inPrivate := ctx.Private.Get(vr.parts[0].s)
 
 			if !inPrivate {
 				// Nothing found? Then have a final lookup in the public context
-				val, currentPresent = ctx.Public[vr.parts[0].s]
+				val, currentPresent = ctx.Public.Get(vr.parts[0].s)
 			}
 			current = reflect.ValueOf(val) // Get the initial value
 


### PR DESCRIPTION
## Description of the change

To allow concurrent access of the Context map, changed it to a `SyncMap`. This is being done through embedding. This required changes like
- Updating the callers
- Exposed a new method `NewContext`
- Updated the methods to have pointer receiver

https://linear.app/rudderstack/issue/PRO-2664/error-from-driver-fatal-error-concurrent-map-read-and-map

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
