### PR TITLE
refactor: rename module to github.com/rudderlabs/pongo2/v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ pongo2 is a Django-syntax like templating-language ([official website](https://w
 Install/update using `go get` (no dependencies required by pongo2):
 
 ```sh
-go get -u github.com/flosch/pongo2/v6
+go get -u github.com/rudderlabs/pongo2/v6
 ```
 
 Please use the [issue tracker](https://github.com/flosch/pongo2/issues) if you're encountering any problems with pongo2 or if you need help with implementing tags or filters ([create a ticket!](https://github.com/flosch/pongo2/issues/new)).
@@ -144,7 +144,7 @@ fmt.Println(out) // Output: Hello Florian!
 package main
 
 import (
-    "github.com/flosch/pongo2/v6"
+    "github.com/rudderlabs/pongo2/v6"
     "net/http"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/flosch/pongo2/v6
+module github.com/rudderlabs/pongo2/v6
 
 go 1.18

--- a/pongo2_issues_test.go
+++ b/pongo2_issues_test.go
@@ -3,7 +3,7 @@ package pongo2_test
 import (
 	"testing"
 
-	"github.com/flosch/pongo2/v6"
+	"github.com/rudderlabs/pongo2/v6"
 )
 
 func TestIssue151(t *testing.T) {

--- a/pongo2_template_test.go
+++ b/pongo2_template_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/flosch/pongo2/v6"
+	"github.com/rudderlabs/pongo2/v6"
 )
 
 type stringerValueType int
@@ -270,8 +270,8 @@ type ObjWithoutAttrs struct {
 	the_attr_field string
 }
 
-func (owa *ObjWithoutAttrs) GetAttr(attrName string) (string, error){
-	if attrName != "attr_name"{
+func (owa *ObjWithoutAttrs) GetAttr(attrName string) (string, error) {
+	if attrName != "attr_name" {
 		return "", fmt.Errorf("unknown attr name '%s'", attrName)
 	}
 	return owa.the_attr_field, nil
@@ -281,7 +281,7 @@ type ObjWithAttrs struct {
 	the_attr_field string
 }
 
-func (owa *ObjWithAttrs) GetAttr(kwargs map[string]*pongo2.Value, args ...*pongo2.Value) (string, error){
+func (owa *ObjWithAttrs) GetAttr(kwargs map[string]*pongo2.Value, args ...*pongo2.Value) (string, error) {
 	if len(args) < 1 {
 		return "", fmt.Errorf("unspecified attr name")
 	}
@@ -289,7 +289,7 @@ func (owa *ObjWithAttrs) GetAttr(kwargs map[string]*pongo2.Value, args ...*pongo
 		return "", fmt.Errorf("attr name not string")
 	}
 	attrName := args[0].String()
-	if attrName != "attr_name"{
+	if attrName != "attr_name" {
 		return "", fmt.Errorf("unknown attr name '%s'", attrName)
 	}
 	res := owa.the_attr_field + " with args ["

--- a/pongo2_test.go
+++ b/pongo2_test.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/flosch/pongo2/v6"
+	"github.com/rudderlabs/pongo2/v6"
 )
 
 var testSuite2 = pongo2.NewSet("test suite 2", pongo2.MustNewLocalFileSystemLoader(""))


### PR DESCRIPTION
## Description of the change

Renaming pongo2 module to `github.com/rudderlabs/pongo2/v6` so that no `replace` directive will be needed in modules that are using it

BEGIN_COMMIT_OVERRIDE
feat: rename module to github.com/rudderlabs/pongo2/v6
END_COMMIT_OVERRIDE