### PR TITLE
feat: if "this" is in pongo env, then treat all its fields as part of env, implicitly.

### DIFF
--- a/pongo2_template_test.go
+++ b/pongo2_template_test.go
@@ -526,6 +526,111 @@ func TestTemplate_Functions(t *testing.T) {
 	}
 }
 
+func TestTemplate_ThisFallback(t *testing.T) {
+	type structWithField struct {
+		Field1 string
+	}
+
+	tests := []struct {
+		name         string
+		template     string
+		context      pongo2.Context
+		want         string
+		errorMessage string
+		wantErr      bool
+	}{
+		{
+			name:     "Map fallback",
+			template: "{{ missing_key }}",
+			context: pongo2.Context{
+				// 'missing_key' does not exist in root context => fallback to `this`.
+				"this": map[string]any{
+					"missing_key": "Hello from map fallback",
+				},
+			},
+			want:    "Hello from map fallback",
+			wantErr: false,
+		},
+		{
+			name:     "Struct fallback",
+			template: "{{ Field1 }}",
+			context: pongo2.Context{
+				// 'Field1' is not in root => fallback to `this.Field1`
+				"this": &structWithField{
+					Field1: "Hello from struct fallback",
+				},
+			},
+			want:    "Hello from struct fallback",
+			wantErr: false,
+		},
+		{
+			name:     "GetAttr fallback",
+			template: "{{ attr_name }}",
+			context: pongo2.Context{
+				// 'attr_name' is not in root => fallback to `this.GetAttr("attr_name")`
+				"this": &ObjWithoutAttrs{
+					the_attr_field: "val_from_getAttr",
+				},
+			},
+			want:    "val_from_getAttr",
+			wantErr: false,
+		},
+		{
+			name:     "No fallback if variable found in root",
+			template: "{{ myvar }}",
+			context: pongo2.Context{
+				// 'myvar' *is* defined in the root context, so we won't use the fallback.
+				"myvar": "root value",
+				"this": map[string]any{
+					"myvar": "fallback value",
+				},
+			},
+			want:    "root value",
+			wantErr: false,
+		},
+		{
+			name:         "Error if not in root nor in 'this'",
+			template:     "{{ notfound }}",
+			context:      pongo2.Context{},
+			errorMessage: "[Error (where: execution) in <string> | Line 1 Col 4 near 'notfound'] No value found for notfound",
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tpl, err := pongo2.FromString(tt.template)
+			if err != nil {
+				t.Errorf("Error compiling template %q: %v", tt.template, err)
+				return
+			}
+			got, err := tpl.Execute(tt.context)
+
+			if err != nil {
+				// We expect an error
+				if !tt.wantErr {
+					t.Errorf("Unexpected error: %v", err)
+					return
+				}
+				// If we *do* expect an error, check message
+				if tt.errorMessage != "" && err.Error() != tt.errorMessage {
+					t.Errorf("Got error = %v, want %v", err.Error(), tt.errorMessage)
+				}
+				return
+			}
+
+			if tt.wantErr {
+				t.Errorf("Expected an error but got none")
+				return
+			}
+
+			if got != tt.want {
+				t.Errorf("Template.Execute() = %q; want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestTemplates(t *testing.T) {
 	// Add a global to the default set
 	pongo2.Globals["this_is_a_global_variable"] = "this is a global text"

--- a/pongo2_template_test.go
+++ b/pongo2_template_test.go
@@ -605,7 +605,6 @@ func TestTemplate_ThisFallback(t *testing.T) {
 				return
 			}
 			got, err := tpl.Execute(tt.context)
-
 			if err != nil {
 				// We expect an error
 				if !tt.wantErr {

--- a/variable.go
+++ b/variable.go
@@ -322,13 +322,16 @@ func (vr *variableResolver) resolve(ctx *ExecutionContext) (*Value, error) {
 							fv = valuePtr.val
 						}
 
-						resolved, found, usedAttr := tryResolveFieldMapOrAttr(fv, part.s)
+						resolved, found, usedAttr, isMap := tryResolveFieldMapOrAttr(fv, part.s)
 						if found {
 							current = resolved
 							currentPresent = true
 							if usedAttr {
 								assumeAttr = true
 							}
+							resolvedUsingThis = true
+						} else if isMap {
+							current = resolved
 							resolvedUsingThis = true
 						}
 					}
@@ -397,14 +400,21 @@ func (vr *variableResolver) resolve(ctx *ExecutionContext) (*Value, error) {
 							current.Kind().String(), vr.String())
 					}
 				case varTypeIdent:
-					nextVal, found, usedAttr := tryResolveFieldMapOrAttr(current, part.s)
+					nextVal, found, usedAttr, isMap := tryResolveFieldMapOrAttr(current, part.s)
 					if found {
 						current = nextVal
 						currentPresent = true
 						if usedAttr {
 							assumeAttr = true
 						}
+					} else if isMap {
+						current = nextVal
+						if usedAttr {
+							assumeAttr = true
+						}
 					} else {
+						fmt.Printf("\ncan't access a field/map key by name on \ntype %s \n\t(variable %s) \n\tcurrent %v\n",
+							current.Kind().String(), vr.String(), current.Interface())
 						return nil, fmt.Errorf("can't access a field/map key by name on type %s (variable %s)",
 							current.Kind().String(), vr.String())
 					}
@@ -690,17 +700,18 @@ func (vr *variableResolver) resolve(ctx *ExecutionContext) (*Value, error) {
 // 1. Struct field
 // 2. Map key
 // 3. getAttr method (if present)
-// Returns (resolvedVal, found, usedAttr).
-func tryResolveFieldMapOrAttr(val reflect.Value, name string) (reflect.Value, bool, bool) {
+// Returns (resolvedVal, found, usedAttr, isMap).
+func tryResolveFieldMapOrAttr(val reflect.Value, name string) (reflect.Value, bool, bool, bool) {
+	isMap := false
 	if !val.IsValid() {
-		return reflect.Value{}, false, false
+		return reflect.Value{}, false, false, isMap
 	}
 
 	// If val is a pointer, deref it
 	if val.Kind() == reflect.Ptr {
 		val = val.Elem()
 		if !val.IsValid() {
-			return reflect.Value{}, false, false
+			return reflect.Value{}, false, false, isMap
 		}
 	}
 
@@ -708,15 +719,17 @@ func tryResolveFieldMapOrAttr(val reflect.Value, name string) (reflect.Value, bo
 	if val.Kind() == reflect.Struct {
 		f := val.FieldByName(name)
 		if f.IsValid() {
-			return f, true, false
+			return f, true, false, isMap
 		}
 	}
 
 	// 2. Map key
+	var m reflect.Value
 	if val.Kind() == reflect.Map {
-		m := val.MapIndex(reflect.ValueOf(name))
+		isMap = true
+		m = val.MapIndex(reflect.ValueOf(name))
 		if m.IsValid() {
-			return m, true, false
+			return m, true, false, isMap
 		}
 	}
 
@@ -725,13 +738,17 @@ func tryResolveFieldMapOrAttr(val reflect.Value, name string) (reflect.Value, bo
 	if !getAttr.IsValid() && val.CanAddr() {
 		getAttr = val.Addr().MethodByName(getAttrMethodName)
 	}
-	return getAttr, getAttr.IsValid(), getAttr.IsValid()
+	if getAttr.IsValid() {
+		return getAttr, true, getAttr.IsValid(), isMap
+	} else if isMap {
+		// Was a map value, but wasn't found
+		return m, false, false, isMap
+	} else {
+		return getAttr, false, getAttr.IsValid(), isMap
+	}
 }
 
 func (vr *variableResolver) Evaluate(ctx *ExecutionContext) (*Value, *Error) {
-        if (vr.locationToken.Val == "inptu_material") {
-              fmt.Println("Hoho")
-        }
 	value, err := vr.resolve(ctx)
 	if err != nil {
 		return AsValue(nil), ctx.Error(err, vr.locationToken)

--- a/variable.go
+++ b/variable.go
@@ -307,6 +307,7 @@ func (vr *variableResolver) resolve(ctx *ExecutionContext) (*Value, error) {
 			}
 
 			// If not found in either private or public, try fallback to "this"
+			resolvedUsingThis := false
 			if !currentPresent {
 				part := vr.parts[0]
 				if part.typ == varTypeIdent {
@@ -328,15 +329,18 @@ func (vr *variableResolver) resolve(ctx *ExecutionContext) (*Value, error) {
 							if usedAttr {
 								assumeAttr = true
 							}
+							resolvedUsingThis = true
 						}
 					}
 				}
 			}
 
-                        if value, ok := val.(*Value); ok {
-				current = value.val
-			} else {
-				current = reflect.ValueOf(val) // Get the initial value
+			if !resolvedUsingThis {
+				if value, ok := val.(*Value); ok {
+					current = value.val
+				} else {
+					current = reflect.ValueOf(val) // Get the initial value
+				}
 			}
 
 		} else {

--- a/variable.go
+++ b/variable.go
@@ -298,12 +298,46 @@ func (vr *variableResolver) resolve(ctx *ExecutionContext) (*Value, error) {
 			// context (e. g. information provided by tags, like the forloop)
 			val, inPrivate := ctx.Private[vr.parts[0].s]
 
-			if !inPrivate {
-				// Nothing found? Then have a final lookup in the public context
+			if inPrivate {
+				// We found it in private
+				currentPresent = true
+			} else {
+				// Not found in private? Then have a final lookup in the public context
 				val, currentPresent = ctx.Public[vr.parts[0].s]
 			}
 
-			current = reflect.ValueOf(val) // Get the initial value
+			// If not found in either private or public, try fallback to "this"
+			if !currentPresent {
+				part := vr.parts[0]
+				if part.typ == varTypeIdent {
+					valThis, inPrivateThis := ctx.Private["this"]
+					inPublicThis := false
+					if !inPrivateThis {
+						valThis, inPublicThis = ctx.Public["this"]
+					}
+					if inPrivateThis || inPublicThis {
+						fv := reflect.ValueOf(valThis)
+						if valuePtr, ok := valThis.(*Value); ok {
+							fv = valuePtr.val
+						}
+
+						resolved, found, usedAttr := tryResolveFieldMapOrAttr(fv, part.s)
+						if found {
+							current = resolved
+							currentPresent = true
+							if usedAttr {
+								assumeAttr = true
+							}
+						}
+					}
+				}
+			}
+
+                        if value, ok := val.(*Value); ok {
+				current = value.val
+			} else {
+				current = reflect.ValueOf(val) // Get the initial value
+			}
 
 		} else {
 			// Next parts, resolve it from current
@@ -359,31 +393,18 @@ func (vr *variableResolver) resolve(ctx *ExecutionContext) (*Value, error) {
 							current.Kind().String(), vr.String())
 					}
 				case varTypeIdent:
-					var tryField reflect.Value
-					// Calling a field or key
-					switch current.Kind() {
-					case reflect.Struct:
-						tryField = current.FieldByName(part.s)
-					case reflect.Map:
-						tryField = current.MapIndex(reflect.ValueOf(part.s))
-					default:
-						return nil, fmt.Errorf("can't access a field by name on type %s (variable %s)",
-							current.Kind().String(), vr.String())
-					}
-					if tryField.IsValid() {
-						current = tryField
-					} else {
-						getAttr := current.MethodByName(getAttrMethodName)
-						if !getAttr.IsValid() && current.CanAddr() {
-							getAttr = current.Addr().MethodByName(getAttrMethodName)
-						}
-						if getAttr.IsValid() {
-							current = getAttr
-							currentPresent = true
+					nextVal, found, usedAttr := tryResolveFieldMapOrAttr(current, part.s)
+					if found {
+						current = nextVal
+						currentPresent = true
+						if usedAttr {
 							assumeAttr = true
 						} else {
 							current = tryField
 						}
+					} else {
+						return nil, fmt.Errorf("can't access a field/map key by name on type %s (variable %s)",
+							current.Kind().String(), vr.String())
 					}
 				case varTypeSubscript:
 					// Calling an index is only possible for:
@@ -663,7 +684,52 @@ func (vr *variableResolver) resolve(ctx *ExecutionContext) (*Value, error) {
 	return &Value{val: current, safe: isSafe}, nil
 }
 
+// tryResolveFieldMapOrAttr tries to resolve `name` from `val` by:
+// 1. Struct field
+// 2. Map key
+// 3. getAttr method (if present)
+// Returns (resolvedVal, found, usedAttr).
+func tryResolveFieldMapOrAttr(val reflect.Value, name string) (reflect.Value, bool, bool) {
+	if !val.IsValid() {
+		return reflect.Value{}, false, false
+	}
+
+	// If val is a pointer, deref it
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+		if !val.IsValid() {
+			return reflect.Value{}, false, false
+		}
+	}
+
+	// 1. Struct field
+	if val.Kind() == reflect.Struct {
+		f := val.FieldByName(name)
+		if f.IsValid() {
+			return f, true, false
+		}
+	}
+
+	// 2. Map key
+	if val.Kind() == reflect.Map {
+		m := val.MapIndex(reflect.ValueOf(name))
+		if m.IsValid() {
+			return m, true, false
+		}
+	}
+
+	// 3. Attempt getAttr fallback
+	getAttr := val.MethodByName(getAttrMethodName)
+	if !getAttr.IsValid() && val.CanAddr() {
+		getAttr = val.Addr().MethodByName(getAttrMethodName)
+	}
+	return getAttr, getAttr.IsValid(), getAttr.IsValid()
+}
+
 func (vr *variableResolver) Evaluate(ctx *ExecutionContext) (*Value, *Error) {
+        if (vr.locationToken.Val == "inptu_material") {
+              fmt.Println("Hoho")
+        }
 	value, err := vr.resolve(ctx)
 	if err != nil {
 		return AsValue(nil), ctx.Error(err, vr.locationToken)

--- a/variable.go
+++ b/variable.go
@@ -403,8 +403,6 @@ func (vr *variableResolver) resolve(ctx *ExecutionContext) (*Value, error) {
 						currentPresent = true
 						if usedAttr {
 							assumeAttr = true
-						} else {
-							current = tryField
 						}
 					} else {
 						return nil, fmt.Errorf("can't access a field/map key by name on type %s (variable %s)",


### PR DESCRIPTION
If there is an object named this in the environment, then treat all its fields, implicitly as part of the pongo2 env.

# Description

If there is an object named this in the environment, then treat all its fields, implicitly as part of the pongo2 env.

## Linear Ticket

https://linear.app/rudderstack/issue/PRO-4494/removing-entity-wrapper-and-input-wrapper

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
