### PR TITLE
chore(ci): migrate from PAT to GitHub App token [SEC-58]

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -19,9 +19,19 @@ jobs:
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
+
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create release commits and tags
+          permission-pull-requests: write # to create release PRs
+
       - uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # v3.7.13
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           pull-request-title-pattern: "chore: release ${version}"
           release-type: go
           package-name: rudder-server


### PR DESCRIPTION
## Summary
Migrates workflow authentication from `secrets.PAT` to GitHub App tokens.

> **Generated by Claude Code** - This PR is part of a batch migration running across ~130 RudderStack repositories.

**Linear:** [SEC-58](https://linear.app/rudderstack/issue/SEC-58/migration-from-pat-to-github-apps)
**Notion:** [Eliminate Github Bot Users](https://www.notion.so/rudderstacks/Elimiate-Github-Bot-Users-and-unverified-commits-296f2b415dd0806b997ddee7058a5969)

## Changes
- Added GitHub App token generation step using `actions/create-github-app-token@v2.1.4`
- Replaced `secrets.PAT` with `${{ steps.generate-token.outputs.token }}`

### Files Modified
- `.github/workflows/release-please.yml`

## Understanding the Permissions

This migration uses **two different permission systems**:

| Permission Type | What It Controls | Where Defined |
|-----------------|------------------|---------------|
| **Workflow `permissions:` block** | What `GITHUB_TOKEN` can do | Top of workflow file |
| **`permission-*` inputs** | What the **GitHub App token** can do | In `create-github-app-token` step |

**Important:** The `permission-contents: write` and `permission-pull-requests: write` inputs scope the **GitHub App token**, not the workflow's `GITHUB_TOKEN`. These are required because release-please needs to:
- Create release commits and tags (`permission-contents: write`)
- Create and update release PRs (`permission-pull-requests: write`)

## Repository Configuration Required
Ensure these are configured at org/repo level:
- `vars.RELEASE_APP_ID` - GitHub App ID
- `secrets.RELEASE_PRIVATE_KEY` - GitHub App private key

## Why This Migration?
1. **Bot account deprecation**: RudderStack is deprecating bot user accounts
2. **Better security**: Short-lived tokens with granular, scoped permissions
3. **Audit trail**: Better tracking of which automation made changes
4. **Triggers downstream workflows**: Unlike `GITHUB_TOKEN`, app tokens trigger PR checks

## Test Plan
- [ ] Trigger workflow manually or via PR event
- [ ] Verify workflow completes successfully
- [ ] Check workflow logs for any authentication errors